### PR TITLE
Changed internal modules dependencies names and auto-version installer

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,9 +7,9 @@ branches:
     - master # This is the original fork
     - original # This is also the original fork
 
-before_script:
-  - rm -rf $HOME/gopath/src/github.com/ParsePlatform/parse-cli
-  - ln -s $HOME/gopath/src/github.com/back4app/parse-cli $HOME/gopath/src/github.com/ParsePlatform/parse-cli
+# before_script:
+#   - rm -rf $HOME/gopath/src/github.com/back4app/parse-cli
+#   - ln -s $HOME/gopath/src/github.com/back4app/parse-cli $HOME/gopath/src/github.com/back4app/parse-cli
 
 script:
   - go test -v ./...

--- a/README.md
+++ b/README.md
@@ -19,11 +19,11 @@ Alternatively, you can just type the following command.
 NOTE: You should already have [Go](https://golang.org/doc/install) installed and GOPATH, GOROOT set to appropriate values.
 
 ```bash
-  go get -t github.com/ParsePlatform/parse-cli
+  go get -t github.com/back4app/parse-cli
 ```
 
 This installs a binary called `parse-cli` at `$GOPATH/bin`.
-Further, you can find the code for Parse CLI at: `$GOPATH/src/github.com/ParsePlatform/parse-cli`.
+Further, you can find the code for Parse CLI at: `$GOPATH/src/github.com/back4app/parse-cli`.
 
 The following commands are currently available in the `Parse Command Line Tool`:
 ```bash

--- a/add.go
+++ b/add.go
@@ -1,8 +1,8 @@
 package main
 
 import (
-	"github.com/ParsePlatform/parse-cli/parsecli"
-	"github.com/ParsePlatform/parse-cli/parsecmd"
+	"github.com/back4app/parse-cli/parsecli"
+	"github.com/back4app/parse-cli/parsecmd"
 	"github.com/facebookgo/stackerr"
 	"github.com/spf13/cobra"
 )

--- a/add_test.go
+++ b/add_test.go
@@ -9,7 +9,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/ParsePlatform/parse-cli/parsecli"
+	"github.com/back4app/parse-cli/parsecli"
 	"github.com/facebookgo/ensure"
 	"github.com/facebookgo/parse"
 )

--- a/configure.go
+++ b/configure.go
@@ -7,8 +7,8 @@ import (
 	"sort"
 	"strconv"
 
-	"github.com/ParsePlatform/parse-cli/parsecli"
-	"github.com/ParsePlatform/parse-cli/webhooks"
+	"github.com/back4app/parse-cli/parsecli"
+	"github.com/back4app/parse-cli/webhooks"
 	"github.com/facebookgo/stackerr"
 	"github.com/spf13/cobra"
 )

--- a/configure_test.go
+++ b/configure_test.go
@@ -7,7 +7,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/ParsePlatform/parse-cli/parsecli"
+	"github.com/back4app/parse-cli/parsecli"
 	"github.com/facebookgo/ensure"
 )
 

--- a/default.go
+++ b/default.go
@@ -1,7 +1,7 @@
 package main
 
 import (
-	"github.com/ParsePlatform/parse-cli/parsecli"
+	"github.com/back4app/parse-cli/parsecli"
 	"github.com/facebookgo/stackerr"
 	"github.com/spf13/cobra"
 )

--- a/default_test.go
+++ b/default_test.go
@@ -7,7 +7,7 @@ import (
 	"regexp"
 	"testing"
 
-	"github.com/ParsePlatform/parse-cli/parsecli"
+	"github.com/back4app/parse-cli/parsecli"
 	"github.com/facebookgo/ensure"
 )
 

--- a/installer.sh
+++ b/installer.sh
@@ -7,8 +7,8 @@ if [ -e ${TMP_FILE} ]; then
 fi
 echo "Fetching latest version ..."
 
-latest="3.0.6-beta-5"
-# latest=$(curl https://parsecli.back4app.com/supported?version=latest)
+# latest="3.0.6-beta-5"
+latest=$(curl https://parsecli.back4app.com/supported?version=latest | grep -Po '\d+.\d+.\d+-beta-\d+')
 
 
 case `uname` in

--- a/installer.sh
+++ b/installer.sh
@@ -13,9 +13,9 @@ latest="3.0.6-beta-5"
 
 case `uname` in
   "Linux" )
-      url="https://github.com/back4app/parse-cli/release/download/release_${latest}/b4a_linux";;
+      url="https://github.com/back4app/parse-cli/release/download/release_${latest}/b4a_linux" ;;
   "Darwin" )
-      url="https://github.com/back4app/parse-cli/release/download/release_${latest}/b4a";;
+      url="https://github.com/back4app/parse-cli/release/download/release_${latest}/b4a" ;;
 esac
 
 

--- a/list.go
+++ b/list.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/ParsePlatform/parse-cli/parsecli"
+	"github.com/back4app/parse-cli/parsecli"
 	"github.com/facebookgo/stackerr"
 	"github.com/spf13/cobra"
 )

--- a/list_test.go
+++ b/list_test.go
@@ -5,7 +5,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/ParsePlatform/parse-cli/parsecli"
+	"github.com/back4app/parse-cli/parsecli"
 	"github.com/facebookgo/ensure"
 )
 

--- a/main.go
+++ b/main.go
@@ -9,7 +9,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/ParsePlatform/parse-cli/parsecli"
+	"github.com/back4app/parse-cli/parsecli"
 	"github.com/facebookgo/clock"
 	"github.com/facebookgo/stackerr"
 )

--- a/main_test.go
+++ b/main_test.go
@@ -6,7 +6,7 @@ import (
 	"regexp"
 	"testing"
 
-	"github.com/ParsePlatform/parse-cli/parsecli"
+	"github.com/back4app/parse-cli/parsecli"
 	"github.com/facebookgo/ensure"
 	"github.com/facebookgo/jsonpipe"
 	"github.com/facebookgo/parse"

--- a/migrate.go
+++ b/migrate.go
@@ -5,7 +5,7 @@ import (
 	"os"
 	"path/filepath"
 
-	"github.com/ParsePlatform/parse-cli/parsecli"
+	"github.com/back4app/parse-cli/parsecli"
 	"github.com/facebookgo/stackerr"
 	"github.com/spf13/cobra"
 )

--- a/migrate_test.go
+++ b/migrate_test.go
@@ -8,7 +8,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/ParsePlatform/parse-cli/parsecli"
+	"github.com/back4app/parse-cli/parsecli"
 	"github.com/facebookgo/ensure"
 )
 

--- a/new.go
+++ b/new.go
@@ -7,8 +7,8 @@ import (
 	"strings"
 	"strconv"
 
-	"github.com/ParsePlatform/parse-cli/parsecli"
-	"github.com/ParsePlatform/parse-cli/parsecmd"
+	"github.com/back4app/parse-cli/parsecli"
+	"github.com/back4app/parse-cli/parsecmd"
 	"github.com/facebookgo/parse"
 	"github.com/facebookgo/stackerr"
 	"github.com/spf13/cobra"

--- a/new_test.go
+++ b/new_test.go
@@ -10,7 +10,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/ParsePlatform/parse-cli/parsecli"
+	"github.com/back4app/parse-cli/parsecli"
 	"github.com/facebookgo/ensure"
 	"github.com/facebookgo/parse"
 )

--- a/parse_commands.go
+++ b/parse_commands.go
@@ -5,9 +5,9 @@ import (
 	"os"
 	"time"
 
-	"github.com/ParsePlatform/parse-cli/parsecli"
-	"github.com/ParsePlatform/parse-cli/parsecmd"
-	"github.com/ParsePlatform/parse-cli/webhooks"
+	"github.com/back4app/parse-cli/parsecli"
+	"github.com/back4app/parse-cli/parsecmd"
+	"github.com/back4app/parse-cli/webhooks"
 	"github.com/spf13/cobra"
 )
 

--- a/parsecmd/add.go
+++ b/parsecmd/add.go
@@ -3,7 +3,7 @@ package parsecmd
 import (
 	"fmt"
 
-	"github.com/ParsePlatform/parse-cli/parsecli"
+	"github.com/back4app/parse-cli/parsecli"
 	"github.com/facebookgo/stackerr"
 )
 

--- a/parsecmd/android_symbol_uploader.go
+++ b/parsecmd/android_symbol_uploader.go
@@ -10,7 +10,7 @@ import (
 	"regexp"
 	"strconv"
 
-	"github.com/ParsePlatform/parse-cli/parsecli"
+	"github.com/back4app/parse-cli/parsecli"
 	"github.com/facebookgo/stackerr"
 )
 

--- a/parsecmd/android_symbol_uploader_test.go
+++ b/parsecmd/android_symbol_uploader_test.go
@@ -8,7 +8,7 @@ import (
 	"regexp"
 	"testing"
 
-	"github.com/ParsePlatform/parse-cli/parsecli"
+	"github.com/back4app/parse-cli/parsecli"
 	"github.com/facebookgo/ensure"
 )
 

--- a/parsecmd/deploy.go
+++ b/parsecmd/deploy.go
@@ -16,7 +16,7 @@ import (
 	"sync"
 	"time"
 
-	"github.com/ParsePlatform/parse-cli/parsecli"
+	"github.com/back4app/parse-cli/parsecli"
 	"github.com/facebookgo/errgroup"
 	"github.com/facebookgo/jsonpipe"
 	"github.com/facebookgo/stackerr"

--- a/parsecmd/deploy_test.go
+++ b/parsecmd/deploy_test.go
@@ -12,7 +12,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/ParsePlatform/parse-cli/parsecli"
+	"github.com/back4app/parse-cli/parsecli"
 	"github.com/facebookgo/ensure"
 	"github.com/facebookgo/parse"
 )

--- a/parsecmd/develop.go
+++ b/parsecmd/develop.go
@@ -5,7 +5,7 @@ import (
 	"net"
 	"time"
 
-	"github.com/ParsePlatform/parse-cli/parsecli"
+	"github.com/back4app/parse-cli/parsecli"
 	"github.com/spf13/cobra"
 )
 

--- a/parsecmd/develop_test.go
+++ b/parsecmd/develop_test.go
@@ -9,7 +9,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/ParsePlatform/parse-cli/parsecli"
+	"github.com/back4app/parse-cli/parsecli"
 	"github.com/facebookgo/ensure"
 )
 

--- a/parsecmd/download.go
+++ b/parsecmd/download.go
@@ -12,7 +12,7 @@ import (
 	"path/filepath"
 	"sync/atomic"
 
-	"github.com/ParsePlatform/parse-cli/parsecli"
+	"github.com/back4app/parse-cli/parsecli"
 	"github.com/facebookgo/errgroup"
 	"github.com/facebookgo/stackerr"
 	"github.com/spf13/cobra"

--- a/parsecmd/download_test.go
+++ b/parsecmd/download_test.go
@@ -9,7 +9,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/ParsePlatform/parse-cli/parsecli"
+	"github.com/back4app/parse-cli/parsecli"
 	"github.com/facebookgo/ensure"
 	"github.com/facebookgo/parse"
 )

--- a/parsecmd/generate.go
+++ b/parsecmd/generate.go
@@ -7,7 +7,7 @@ import (
 	"path/filepath"
 	"strings"
 
-	"github.com/ParsePlatform/parse-cli/parsecli"
+	"github.com/back4app/parse-cli/parsecli"
 	"github.com/facebookgo/stackerr"
 	"github.com/spf13/cobra"
 )

--- a/parsecmd/generate_test.go
+++ b/parsecmd/generate_test.go
@@ -8,7 +8,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/ParsePlatform/parse-cli/parsecli"
+	"github.com/back4app/parse-cli/parsecli"
 	"github.com/facebookgo/ensure"
 )
 

--- a/parsecmd/ios_symbol_uploader.go
+++ b/parsecmd/ios_symbol_uploader.go
@@ -10,7 +10,7 @@ import (
 	"runtime"
 
 	"github.com/DHowett/go-plist"
-	"github.com/ParsePlatform/parse-cli/parsecli"
+	"github.com/back4app/parse-cli/parsecli"
 	"github.com/facebookgo/stackerr"
 	"github.com/inconshreveable/go-update"
 	"github.com/mitchellh/go-homedir"

--- a/parsecmd/ios_symbol_uploader_test.go
+++ b/parsecmd/ios_symbol_uploader_test.go
@@ -7,7 +7,7 @@ import (
 	"runtime"
 	"testing"
 
-	"github.com/ParsePlatform/parse-cli/parsecli"
+	"github.com/back4app/parse-cli/parsecli"
 	"github.com/facebookgo/ensure"
 )
 

--- a/parsecmd/jssdk.go
+++ b/parsecmd/jssdk.go
@@ -5,7 +5,7 @@ import (
 	"net/url"
 	"sort"
 
-	"github.com/ParsePlatform/parse-cli/parsecli"
+	"github.com/back4app/parse-cli/parsecli"
 	"github.com/facebookgo/stackerr"
 	"github.com/spf13/cobra"
 )

--- a/parsecmd/jssdk_test.go
+++ b/parsecmd/jssdk_test.go
@@ -9,7 +9,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/ParsePlatform/parse-cli/parsecli"
+	"github.com/back4app/parse-cli/parsecli"
 	"github.com/facebookgo/ensure"
 	"github.com/facebookgo/parse"
 )

--- a/parsecmd/logs.go
+++ b/parsecmd/logs.go
@@ -7,7 +7,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/ParsePlatform/parse-cli/parsecli"
+	"github.com/back4app/parse-cli/parsecli"
 	"github.com/facebookgo/stackerr"
 	"github.com/spf13/cobra"
 )

--- a/parsecmd/logs_test.go
+++ b/parsecmd/logs_test.go
@@ -8,7 +8,7 @@ import (
 	"sync/atomic"
 	"testing"
 
-	"github.com/ParsePlatform/parse-cli/parsecli"
+	"github.com/back4app/parse-cli/parsecli"
 	"github.com/facebookgo/ensure"
 	"github.com/facebookgo/parse"
 )

--- a/parsecmd/new.go
+++ b/parsecmd/new.go
@@ -3,7 +3,7 @@ package parsecmd
 import (
 	"fmt"
 
-	"github.com/ParsePlatform/parse-cli/parsecli"
+	"github.com/back4app/parse-cli/parsecli"
 	"github.com/facebookgo/parse"
 )
 

--- a/parsecmd/parse_symbol_uploader.go
+++ b/parsecmd/parse_symbol_uploader.go
@@ -12,7 +12,7 @@ import (
 	"path"
 	"path/filepath"
 
-	"github.com/ParsePlatform/parse-cli/parsecli"
+	"github.com/back4app/parse-cli/parsecli"
 	"github.com/facebookgo/errgroup"
 	"github.com/facebookgo/stackerr"
 )

--- a/parsecmd/parse_symbol_uploader_test.go
+++ b/parsecmd/parse_symbol_uploader_test.go
@@ -10,7 +10,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/ParsePlatform/parse-cli/parsecli"
+	"github.com/back4app/parse-cli/parsecli"
 	"github.com/facebookgo/ensure"
 	"github.com/facebookgo/parse"
 )

--- a/parsecmd/parseignore.go
+++ b/parsecmd/parseignore.go
@@ -6,7 +6,7 @@ import (
 	"path/filepath"
 	"strings"
 
-	"github.com/ParsePlatform/parse-cli/parsecli"
+	"github.com/back4app/parse-cli/parsecli"
 	"github.com/facebookgo/parseignore"
 	"github.com/facebookgo/symwalk"
 )

--- a/parsecmd/releases.go
+++ b/parsecmd/releases.go
@@ -8,7 +8,7 @@ import (
 	"strings"
 	"text/tabwriter"
 
-	"github.com/ParsePlatform/parse-cli/parsecli"
+	"github.com/back4app/parse-cli/parsecli"
 	"github.com/facebookgo/stackerr"
 	"github.com/spf13/cobra"
 )

--- a/parsecmd/releases_test.go
+++ b/parsecmd/releases_test.go
@@ -7,7 +7,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/ParsePlatform/parse-cli/parsecli"
+	"github.com/back4app/parse-cli/parsecli"
 	"github.com/facebookgo/ensure"
 	"github.com/facebookgo/parse"
 	"github.com/facebookgo/stackerr"

--- a/parsecmd/rollback.go
+++ b/parsecmd/rollback.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"net/url"
 
-	"github.com/ParsePlatform/parse-cli/parsecli"
+	"github.com/back4app/parse-cli/parsecli"
 	"github.com/facebookgo/stackerr"
 	"github.com/spf13/cobra"
 )

--- a/parsecmd/rollback_test.go
+++ b/parsecmd/rollback_test.go
@@ -8,7 +8,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/ParsePlatform/parse-cli/parsecli"
+	"github.com/back4app/parse-cli/parsecli"
 	"github.com/facebookgo/ensure"
 	"github.com/facebookgo/parse"
 )

--- a/parsecmd/symbols.go
+++ b/parsecmd/symbols.go
@@ -3,7 +3,7 @@ package parsecmd
 import (
 	"fmt"
 
-	"github.com/ParsePlatform/parse-cli/parsecli"
+	"github.com/back4app/parse-cli/parsecli"
 	"github.com/facebookgo/stackerr"
 	"github.com/spf13/cobra"
 )

--- a/parsecmd/symbols_test.go
+++ b/parsecmd/symbols_test.go
@@ -4,7 +4,7 @@ import (
 	"regexp"
 	"testing"
 
-	"github.com/ParsePlatform/parse-cli/parsecli"
+	"github.com/back4app/parse-cli/parsecli"
 	"github.com/facebookgo/ensure"
 )
 

--- a/update.go
+++ b/update.go
@@ -6,7 +6,7 @@ import (
 	"net/url"
 	"runtime"
 
-	"github.com/ParsePlatform/parse-cli/parsecli"
+	"github.com/back4app/parse-cli/parsecli"
 	"github.com/facebookgo/stackerr"
 	"github.com/inconshreveable/go-update"
 	"github.com/kardianos/osext"

--- a/update_test.go
+++ b/update_test.go
@@ -5,7 +5,7 @@ import (
 	"net/http"
 	"testing"
 
-	"github.com/ParsePlatform/parse-cli/parsecli"
+	"github.com/back4app/parse-cli/parsecli"
 	"github.com/facebookgo/ensure"
 	"github.com/facebookgo/jsonpipe"
 	"github.com/facebookgo/parse"

--- a/utils.go
+++ b/utils.go
@@ -6,7 +6,7 @@ import (
 	"net/url"
 	"strings"
 
-	"github.com/ParsePlatform/parse-cli/parsecli"
+	"github.com/back4app/parse-cli/parsecli"
 	"github.com/facebookgo/stackerr"
 )
 

--- a/version.go
+++ b/version.go
@@ -3,7 +3,7 @@ package main
 import (
 	"fmt"
 
-	"github.com/ParsePlatform/parse-cli/parsecli"
+	"github.com/back4app/parse-cli/parsecli"
 	"github.com/spf13/cobra"
 )
 

--- a/version_test.go
+++ b/version_test.go
@@ -3,7 +3,7 @@ package main
 import (
 	"testing"
 
-	"github.com/ParsePlatform/parse-cli/parsecli"
+	"github.com/back4app/parse-cli/parsecli"
 	"github.com/facebookgo/ensure"
 )
 

--- a/webhooks/functions.go
+++ b/webhooks/functions.go
@@ -8,7 +8,7 @@ import (
 	"sort"
 	"strings"
 
-	"github.com/ParsePlatform/parse-cli/parsecli"
+	"github.com/back4app/parse-cli/parsecli"
 	"github.com/facebookgo/stackerr"
 	"github.com/spf13/cobra"
 )

--- a/webhooks/functions_test.go
+++ b/webhooks/functions_test.go
@@ -9,7 +9,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/ParsePlatform/parse-cli/parsecli"
+	"github.com/back4app/parse-cli/parsecli"
 	"github.com/facebookgo/ensure"
 	"github.com/facebookgo/jsonpipe"
 	"github.com/facebookgo/parse"

--- a/webhooks/hooks.go
+++ b/webhooks/hooks.go
@@ -11,7 +11,7 @@ import (
 	"path"
 	"strings"
 
-	"github.com/ParsePlatform/parse-cli/parsecli"
+	"github.com/back4app/parse-cli/parsecli"
 	"github.com/facebookgo/stackerr"
 )
 

--- a/webhooks/hooks_test.go
+++ b/webhooks/hooks_test.go
@@ -7,7 +7,7 @@ import (
 	"regexp"
 	"testing"
 
-	"github.com/ParsePlatform/parse-cli/parsecli"
+	"github.com/back4app/parse-cli/parsecli"
 	"github.com/facebookgo/ensure"
 )
 

--- a/webhooks/triggers.go
+++ b/webhooks/triggers.go
@@ -8,7 +8,7 @@ import (
 	"sort"
 	"strings"
 
-	"github.com/ParsePlatform/parse-cli/parsecli"
+	"github.com/back4app/parse-cli/parsecli"
 	"github.com/facebookgo/stackerr"
 	"github.com/spf13/cobra"
 )

--- a/webhooks/triggers_test.go
+++ b/webhooks/triggers_test.go
@@ -10,7 +10,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/ParsePlatform/parse-cli/parsecli"
+	"github.com/back4app/parse-cli/parsecli"
 	"github.com/facebookgo/ensure"
 	"github.com/facebookgo/jsonpipe"
 	"github.com/facebookgo/parse"


### PR DESCRIPTION
Changed `github.com/ParsePlatform/parse-cli` (original source names) to `github.com/back4app/parse-cli`.
Now we don't need to make anything before travis runs.

Now the installer grabs the version from the server, no need for updated the installer after each release

(No need of a new release for this PR)